### PR TITLE
fix: skip attachment downloads for already-persisted catchup messages

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -108,6 +108,14 @@ export const insertStmt = db.prepare(`
   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 `);
 
+const existsByExternalIdStmt = db.prepare(
+  "SELECT 1 FROM messages WHERE source = ? AND external_id = ? LIMIT 1",
+);
+
+export function hasMessageByExternalId(source: string, externalId: string): boolean {
+  return existsByExternalIdStmt.get(source, externalId) != null;
+}
+
 export function getChannelPrompt(channelId: string): { prompt: string; messageId: string; updatedBy: string | null; updatedAt: string } | null {
   try {
     const row = db.prepare("SELECT prompt, message_id, updated_by, updated_at FROM channel_prompts WHERE channel_id = ?").get(channelId) as any;

--- a/server/messages.ts
+++ b/server/messages.ts
@@ -4,7 +4,7 @@
 
 import { fetchAttachmentContent } from "./attachment.ts";
 import { CLAUDE_AGENT_ID, DEFAULT_CHANNEL_ID, DISCORD_SESSION_ID, MESSAGE_ROUTING_MODE } from "./config.ts";
-import { insertStmt } from "./db.ts";
+import { hasMessageByExternalId, insertStmt } from "./db.ts";
 import { appendMemoryTurn } from "./memory.ts";
 
 export async function formatInboundMessage(message: any) {
@@ -34,6 +34,12 @@ export async function formatInboundMessage(message: any) {
 }
 
 export async function persistInboundDiscordMessage(message: any): Promise<boolean> {
+  // Skip already-persisted messages before hydrating attachments, so restart
+  // catch-up doesn't re-download binaries for messages we've already stored.
+  if (message.id && hasMessageByExternalId("discord", message.id)) {
+    return false;
+  }
+
   const normalizedContent = await formatInboundMessage(message);
   // In channel mode, route to channelId so per-channel subagents consume independently.
   // In agent mode (legacy), route to CLAUDE_AGENT_ID for single-agent consumption.


### PR DESCRIPTION
## Summary

- Restart catch-up was re-downloading every attachment in the last 100 messages of every allowed channel and thread, even when those messages were already in the database.
- Dedup was actually working via the `UNIQUE(source, external_id)` index — no duplicate rows were being inserted — but `formatInboundMessage` ran before the insert, so `fetchAttachmentContent` hit Discord's CDN for every attachment before the UNIQUE constraint finally rejected the insert. The catch block at `server/messages.ts` silently swallowed the duplicate.
- Add `hasMessageByExternalId` in `server/db.ts` (prepared `SELECT 1 ... LIMIT 1` against the existing unique index) and short-circuit `persistInboundDiscordMessage` before attachment hydration when the row already exists.

## Why

On every restart the user saw dozens of `[Relay] Downloaded attachment voice-message.ogg ...` log lines for messages from days or weeks ago. Bandwidth, disk writes, and startup latency all scaled with `CATCHUP_MESSAGE_LIMIT × attachments-per-message`. Now the lookup is a single indexed SQLite hit per catch-up message for already-seen messages, and downloads only happen for messages not yet in the DB.

## Reviewer notes

- Catchup still refetches the last `CATCHUP_MESSAGE_LIMIT` message headers from Discord on every restart — there's no per-channel watermark. That's unchanged and out of scope here; the fix just makes the dedup cheap instead of expensive.
- The live-message path (`server/index.ts:208`) also benefits: if Discord ever re-delivers an event we've already stored, we'll skip the attachment hydration there too.
- Behavior for genuinely new messages is unchanged — they still hit `formatInboundMessage` and get attachments downloaded on first sight.

## Test plan

- [ ] Restart the relay against a Discord server with existing attachment history; confirm no `[Relay] Downloaded attachment` lines fire for messages already persisted.
- [ ] Post a new message with an attachment while the relay is offline, restart, confirm the attachment is downloaded exactly once during catch-up.
- [ ] Restart again; confirm the same attachment is not re-downloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)